### PR TITLE
Add missing translation key for team update errors

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -183,7 +183,8 @@
     "saveSettings": "Save Settings",
     "year": "Year",
     "financials": "Financials",
-    "budgetComparison": "Budget Comparison"
+    "budgetComparison": "Budget Comparison",
+    "teamUpdateError": "Failed to update team"
   },
   "dialog": {
     "areYouSure": "Are you sure?",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -184,7 +184,8 @@
     "saveSettings": "Guardar Configurações",
     "year": "Ano",
     "financials": "Finanças",
-    "budgetComparison": "Orçamentos"
+    "budgetComparison": "Orçamentos",
+    "teamUpdateError": "Erro ao atualizar equipa"
   },
   "dialog": {
     "areYouSure": "Tem a certeza?",


### PR DESCRIPTION
## Summary
- add `teamUpdateError` message to English and Portuguese locales

## Testing
- `jq empty src/i18n/locales/en.json`
- `jq empty src/i18n/locales/pt.json`
- `bun test` *(fails: Cannot find module 'react/jsx-dev-runtime')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847ef24cdf48324be9dbfbf613bddce